### PR TITLE
fix/api

### DIFF
--- a/lib/DateSelect.tsx
+++ b/lib/DateSelect.tsx
@@ -24,51 +24,49 @@ export interface DateSelectProps extends ReactHookFormCompatibleProps {
   defaultDay?: number;
 }
 
-const DateSelect = React.forwardRef<HTMLInputElement, DateSelectProps>(
-  (props, ref) => {
-    // Ref is forwarded, but it is intended to be used with react-hook-form's <Controller /> to focus the input when error occurs.
-    // This component is still controlled even if ref is here.
+const DateSelect = React.forwardRef<unknown, DateSelectProps>((props, ref) => {
+  // Ref is forwarded, but it is intended to be used with react-hook-form's <Controller /> to focus the input when error occurs.
+  // This component is still controlled even if ref is here.
 
-    const {
-      onChange,
-      value,
-      maxYear,
-      minYear,
-      defaultYear,
-      defaultMonth,
-      defaultDay,
-    } = props;
+  const {
+    onChange,
+    value,
+    maxYear,
+    minYear,
+    defaultYear,
+    defaultMonth,
+    defaultDay,
+  } = props;
 
-    const dateSelectProps = useDateSelect({
-      minYear,
-      maxYear,
-      onChange,
-      defaultYear,
-      defaultMonth,
-      defaultDay,
-    });
+  const dateSelectProps = useDateSelect({
+    minYear,
+    maxYear,
+    onChange,
+    defaultYear,
+    defaultMonth,
+    defaultDay,
+  });
 
-    const { setDate, dateValue } = dateSelectProps;
-    useEffect(() => {
-      if (typeof value !== "string") {
-        return;
-      }
-
-      const dateValueAsString = dateValue || "";
-      if (dateValueAsString !== value) {
-        setDate(value);
-      }
-    }, [setDate, dateValue, value]);
-
-    if (props.component) {
-      return React.createElement(props.component, { ref, ...dateSelectProps });
-    } else if (props.render) {
-      return props.render({ ...dateSelectProps, ref });
-    } else {
-      throw new Error(`Either render or component must be provided.`);
+  const { setDate, dateValue } = dateSelectProps;
+  useEffect(() => {
+    if (typeof value !== "string") {
+      return;
     }
+
+    const dateValueAsString = dateValue || "";
+    if (dateValueAsString !== value) {
+      setDate(value);
+    }
+  }, [setDate, dateValue, value]);
+
+  if (props.component) {
+    return React.createElement(props.component, { ref, ...dateSelectProps });
+  } else if (props.render) {
+    return props.render({ ...dateSelectProps, ref });
+  } else {
+    throw new Error(`Either render or component must be provided.`);
   }
-);
+});
 DateSelect.displayName = "DateSelect";
 
 export default DateSelect;

--- a/lib/DateSelect.tsx
+++ b/lib/DateSelect.tsx
@@ -11,7 +11,9 @@ interface ReactHookFormCompatibleProps {
 export interface ChildComponentProps extends UseDateSelectInterface {
   ref?: React.Ref<any>;
 }
-export type RenderArgs = UseDateSelectInterface;
+export interface RenderArgs extends UseDateSelectInterface {
+  ref?: React.Ref<any>;
+}
 export interface DateSelectProps extends ReactHookFormCompatibleProps {
   component?: React.ComponentType<ChildComponentProps>;
   render?: (renderArgs: RenderArgs) => React.ReactElement;
@@ -61,7 +63,7 @@ const DateSelect = React.forwardRef<HTMLInputElement, DateSelectProps>(
     if (props.component) {
       return React.createElement(props.component, { ref, ...dateSelectProps });
     } else if (props.render) {
-      return props.render({ ...dateSelectProps });
+      return props.render({ ...dateSelectProps, ref });
     } else {
       throw new Error(`Either render or component must be provided.`);
     }

--- a/lib/DateSelect.tsx
+++ b/lib/DateSelect.tsx
@@ -8,11 +8,13 @@ interface ReactHookFormCompatibleProps {
   onBlur?: () => void;
 }
 
-export interface RenderProps extends ReturnType<typeof useDateSelect> {
-  ref: React.Ref<any>;
+export interface ChildComponentProps extends ReturnType<typeof useDateSelect> {
+  ref?: React.Ref<any>;
 }
+export type RenderArgs = ReturnType<typeof useDateSelect>;
 export interface DateSelectProps extends ReactHookFormCompatibleProps {
-  render: (renderProps: RenderProps) => React.ReactElement;
+  component?: React.ComponentType<ChildComponentProps>;
+  render?: (renderArgs: RenderArgs) => React.ReactElement;
   maxYear?: number;
   minYear?: number;
   defaultYear?: number;
@@ -56,7 +58,13 @@ const DateSelect = React.forwardRef<HTMLInputElement, DateSelectProps>(
       }
     }, [setDate, dateValue, value]);
 
-    return props.render({ ...dateSelectProps, ref });
+    if (props.component) {
+      return React.createElement(props.component, { ref, ...dateSelectProps });
+    } else if (props.render) {
+      return props.render({ ...dateSelectProps });
+    } else {
+      throw new Error(`Either render or component must be provided.`);
+    }
   }
 );
 DateSelect.displayName = "DateSelect";

--- a/lib/DateSelect.tsx
+++ b/lib/DateSelect.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { useDateSelect } from "./use-date-select";
+import { useDateSelect, UseDateSelectInterface } from "./use-date-select";
 
 interface ReactHookFormCompatibleProps {
   value: string;
@@ -8,10 +8,10 @@ interface ReactHookFormCompatibleProps {
   onBlur?: () => void;
 }
 
-export interface ChildComponentProps extends ReturnType<typeof useDateSelect> {
+export interface ChildComponentProps extends UseDateSelectInterface {
   ref?: React.Ref<any>;
 }
-export type RenderArgs = ReturnType<typeof useDateSelect>;
+export type RenderArgs = UseDateSelectInterface;
 export interface DateSelectProps extends ReactHookFormCompatibleProps {
   component?: React.ComponentType<ChildComponentProps>;
   render?: (renderArgs: RenderArgs) => React.ReactElement;

--- a/lib/DateSelect.tsx
+++ b/lib/DateSelect.tsx
@@ -9,10 +9,10 @@ interface ReactHookFormCompatibleProps {
 }
 
 export interface ChildComponentProps extends UseDateSelectInterface {
-  ref?: React.Ref<any>;
+  ref?: React.Ref<unknown>;
 }
 export interface RenderArgs extends UseDateSelectInterface {
-  ref?: React.Ref<any>;
+  ref?: React.Ref<unknown>;
 }
 export interface DateSelectProps extends ReactHookFormCompatibleProps {
   component?: React.ComponentType<ChildComponentProps>;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,8 @@
-export { default as DateSelect, DateSelectProps } from "./DateSelect";
+export {
+  default as DateSelect,
+  type DateSelectProps,
+  type ChildComponentProps,
+  type RenderArgs,
+} from "./DateSelect";
 export * from "./use-date-select";
 export * from "./types";

--- a/lib/presets/chakra-ui/DateDropdownGroup.tsx
+++ b/lib/presets/chakra-ui/DateDropdownGroup.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Options } from "../../types";
 import { Select, HStack } from "@chakra-ui/react";
 
-interface DateDropdownGroupProps {
+export interface DateDropdownGroupProps {
   yearValue: string;
   monthValue: string;
   dayValue: string;

--- a/lib/presets/chakra-ui/DateSelect.tsx
+++ b/lib/presets/chakra-ui/DateSelect.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import DateDropdownGroup from "./DateDropdownGroup";
 import Base, { DateSelectProps as BaseProps } from "../../DateSelect";
 
@@ -5,18 +6,20 @@ export interface DateSelectProps extends Omit<BaseProps, "render"> {
   hideDay?: boolean;
 }
 
-function DateSelect(props: DateSelectProps) {
+const DateSelect = React.forwardRef<unknown, DateSelectProps>((props, ref) => {
   return (
     <Base
       {...props}
       defaultDay={
         props.defaultDay ? props.defaultDay : props.hideDay ? 1 : undefined
       }
-      render={(renderProps) => (
+      ref={ref}
+      render={({ ref, ...renderProps }) => (
         <DateDropdownGroup {...renderProps} hideDay={props.hideDay} />
       )}
     />
   );
-}
+});
+DateSelect.displayName = "DateSelect";
 
 export default DateSelect;

--- a/lib/presets/chakra-ui/index.ts
+++ b/lib/presets/chakra-ui/index.ts
@@ -1,2 +1,5 @@
 export { default as DateSelect } from "./DateSelect";
-export { default as DateDropdownGroup } from "./DateDropdownGroup";
+export {
+  default as DateDropdownGroup,
+  type DateDropdownGroupProps,
+} from "./DateDropdownGroup";

--- a/lib/presets/material/DateDropdownGroup.tsx
+++ b/lib/presets/material/DateDropdownGroup.tsx
@@ -6,7 +6,7 @@ import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select, { SelectProps } from "@mui/material/Select";
 
-interface DateDropdownGroupProps {
+export interface DateDropdownGroupProps {
   yearValue: string;
   monthValue: string;
   dayValue: string;

--- a/lib/presets/material/DateSelect.tsx
+++ b/lib/presets/material/DateSelect.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import DateDropdownGroup from "./DateDropdownGroup";
 import Base, { DateSelectProps as BaseProps } from "../../DateSelect";
 
@@ -5,18 +6,20 @@ export interface DateSelectProps extends Omit<BaseProps, "render"> {
   hideDay?: boolean;
 }
 
-function DateSelect(props: DateSelectProps) {
+const DateSelect = React.forwardRef<unknown, DateSelectProps>((props, ref) => {
   return (
     <Base
       {...props}
       defaultDay={
         props.defaultDay ? props.defaultDay : props.hideDay ? 1 : undefined
       }
-      render={(renderProps) => (
+      ref={ref}
+      render={({ ref, ...renderProps }) => (
         <DateDropdownGroup {...renderProps} hideDay={props.hideDay} />
       )}
     />
   );
-}
+});
+DateSelect.displayName = "DateSelect";
 
 export default DateSelect;

--- a/lib/presets/material/index.ts
+++ b/lib/presets/material/index.ts
@@ -1,2 +1,5 @@
 export { default as DateSelect } from "./DateSelect";
-export { default as DateDropdownGroup } from "./DateDropdownGroup";
+export {
+  default as DateDropdownGroup,
+  type DateDropdownGroupProps,
+} from "./DateDropdownGroup";

--- a/lib/presets/vanilla/DateDropdownGroup.tsx
+++ b/lib/presets/vanilla/DateDropdownGroup.tsx
@@ -1,6 +1,6 @@
 import { Options } from "../../types";
 
-interface DateDropdownGroupProps {
+export interface DateDropdownGroupProps {
   yearValue: string;
   monthValue: string;
   dayValue: string;

--- a/lib/presets/vanilla/DateSelect.tsx
+++ b/lib/presets/vanilla/DateSelect.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import DateDropdownGroup from "./DateDropdownGroup";
 import Base, { DateSelectProps as BaseProps } from "../../DateSelect";
 
@@ -5,18 +6,20 @@ export interface DateSelectProps extends Omit<BaseProps, "render"> {
   hideDay?: boolean;
 }
 
-function DateSelect(props: DateSelectProps) {
+const DateSelect = React.forwardRef<unknown, DateSelectProps>((props, ref) => {
   return (
     <Base
       {...props}
       defaultDay={
         props.defaultDay ? props.defaultDay : props.hideDay ? 1 : undefined
       }
-      render={(renderProps) => (
+      ref={ref}
+      render={({ ref, ...renderProps }) => (
         <DateDropdownGroup {...renderProps} hideDay={props.hideDay} />
       )}
     />
   );
-}
+});
+DateSelect.displayName = "DateSelect";
 
 export default DateSelect;

--- a/lib/presets/vanilla/index.ts
+++ b/lib/presets/vanilla/index.ts
@@ -1,2 +1,5 @@
 export { default as DateSelect } from "./DateSelect";
-export { default as DateDropdownGroup } from "./DateDropdownGroup";
+export {
+  default as DateDropdownGroup,
+  type DateDropdownGroupProps,
+} from "./DateDropdownGroup";

--- a/lib/use-date-select.ts
+++ b/lib/use-date-select.ts
@@ -39,7 +39,23 @@ export interface UseDateSelectOptions {
   defaultDay?: number;
   onChange: (dateString: string) => void;
 }
-export const useDateSelect = (opts: UseDateSelectOptions) => {
+export interface UseDateSelectInterface {
+  yearValue: string;
+  monthValue: string;
+  dayValue: string;
+  yearOptions: Options;
+  monthOptions: Options;
+  dayOptions: Options;
+  onYearChange: (e: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  onMonthChange: (e: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  onDayChange: (e: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  dateValue: string | null;
+  onDateChange: (e: React.ChangeEvent<HTMLInputElement> | string) => void;
+  setDate: (dateString: string) => void;
+}
+export const useDateSelect = (
+  opts: UseDateSelectOptions
+): UseDateSelectInterface => {
   const [state, setState] = useState<DateSelectState & { changeCount: number }>(
     {
       yearValue: opts.defaultYear ? convertToSelectValue(opts.defaultYear) : "",

--- a/samples/vanilla/App.tsx
+++ b/samples/vanilla/App.tsx
@@ -1,6 +1,6 @@
 import VanillaReactHookFormSample from "./react-hook-form";
 import VanillaReactHookFormWithDefaultValueSample from "./react-hook-form-default-value";
-import VanillaReactHookFormWithOriginalRenderSample from "./react-hook-form-with-original-render";
+import VanillaReactHookFormWithCustomComponentSample from "./react-hook-form-with-custom-component";
 import VanillaReactHookFormWithPartialDefaultValueSample from "./react-hook-form-with-partial-default-value";
 import VanillaReactHookFormHideDaySample from "./react-hook-form-hide-day";
 
@@ -9,7 +9,7 @@ function App() {
     <div>
       <VanillaReactHookFormSample />
       <VanillaReactHookFormWithDefaultValueSample />
-      <VanillaReactHookFormWithOriginalRenderSample />
+      <VanillaReactHookFormWithCustomComponentSample />
       <VanillaReactHookFormWithPartialDefaultValueSample />
       <VanillaReactHookFormHideDaySample />
     </div>

--- a/samples/vanilla/react-hook-form-with-custom-component.tsx
+++ b/samples/vanilla/react-hook-form-with-custom-component.tsx
@@ -25,7 +25,7 @@ type FormData = {
   date: string;
 };
 
-function VanillaReactHookFormWithOriginalRenderSample() {
+function VanillaReactHookFormWithCustomComponentSample() {
   const {
     control,
     handleSubmit,
@@ -53,4 +53,4 @@ function VanillaReactHookFormWithOriginalRenderSample() {
   );
 }
 
-export default VanillaReactHookFormWithOriginalRenderSample;
+export default VanillaReactHookFormWithCustomComponentSample;

--- a/samples/vanilla/react-hook-form-with-original-render.tsx
+++ b/samples/vanilla/react-hook-form-with-original-render.tsx
@@ -1,6 +1,25 @@
+import React from "react";
 import { useForm, Controller } from "react-hook-form";
-import { DateSelect } from "../../lib";
+import { DateSelect, ChildComponentProps } from "../../lib";
 import { DateDropdownGroup } from "../../lib/presets/vanilla";
+
+// Creating a new component wrapped with `React.forwardRef` is necessary to use `ref` inside it.
+const CustomComponent = React.forwardRef<HTMLInputElement, ChildComponentProps>(
+  (props, ref) => {
+    return (
+      <>
+        <input
+          type="date"
+          value={props.dateValue || ""}
+          onChange={props.onDateChange}
+          ref={ref}
+        />
+        <DateDropdownGroup {...props} />
+      </>
+    );
+  }
+);
+CustomComponent.displayName = "CustomComponent";
 
 type FormData = {
   date: string;
@@ -24,20 +43,7 @@ function VanillaReactHookFormWithOriginalRenderSample() {
         control={control}
         rules={{ required: true }}
         render={({ field }) => (
-          <DateSelect
-            {...field}
-            render={(props) => (
-              <>
-                <input
-                  type="date"
-                  value={props.dateValue || ""}
-                  onChange={props.onDateChange}
-                  ref={props.ref}
-                />
-                <DateDropdownGroup {...props} />
-              </>
-            )}
-          />
+          <DateSelect {...field} component={CustomComponent} />
         )}
       />
       {errors.date && <span>This field is required</span>}


### PR DESCRIPTION
- Export DateDropdownGroupProps
- Add component prop on <DateSelect />
- Export UseDateSelectInterface
- Add ref to RenderArgs
- Fix ref type to be unknown
- Update presets/*/DateSelect.tsx to forward ref
- Fix samples/vanilla/react-hook-form-with-original-render.tsx to use component props
- Rename samples/vanilla/react-hook-form-with-original-render.tsx -> samples/vanilla/react-hook-form-with-custom-component.tsx
